### PR TITLE
Applicaction.ThreadException event translation improvement

### DIFF
--- a/xml/System.Windows.Forms/Application.xml
+++ b/xml/System.Windows.Forms/Application.xml
@@ -1720,7 +1720,7 @@ Ce chemin d'accès sera différent selon que l'application Windows Forms est dé
         <ReturnType>System.Threading.ThreadExceptionEventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Se produit lorsqu'une exception non gérée est levée sur un thread.</summary>
+        <summary>Se produit lorsqu'une exception non gérée est levée sur un thread d'interface utilisateur.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   

--- a/xml/System.Windows.Forms/Application.xml
+++ b/xml/System.Windows.Forms/Application.xml
@@ -1720,27 +1720,27 @@ Ce chemin d'accès sera différent selon que l'application Windows Forms est dé
         <ReturnType>System.Threading.ThreadExceptionEventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Se produit lorsqu'une exception de thread ininterrompu est levée.</summary>
+        <summary>Se produit lorsqu'une exception non gérée est levée sur un thread.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- Cet événement permet à votre application Windows Forms pour gérer sinon non prise en charge les exceptions qui se produisent dans les threads de Windows Forms. Attachez vos gestionnaires d’événements pour le <xref:System.Windows.Forms.Application.ThreadException> événements pour traiter ces exceptions, ce qui laissent votre application dans un état inconnu. Si possible, les exceptions doivent être gérées par une bloc structurée des exceptions.  
+ Cet événement permet à votre application Windows Forms de gérer les exceptions non prises en charge qui se produisent dans les threads de Windows Forms. Attachez vos gestionnaires à l'événement <xref:System.Windows.Forms.Application.ThreadException> pour traiter ces exceptions, ce qui laissera votre application dans un état indeterminé. Dans la mesure du possible, les exceptions doivent être gérées localement par un bloc structurant de gestion d'exceptions.
   
- Vous pouvez choisir si ce rappel est utilisé pour les exceptions de thread Windows Forms non gérées en définissant <xref:System.Windows.Forms.Application.SetUnhandledExceptionMode%2A>. Pour intercepter les exceptions qui se produisent dans les threads non créés et détenus par les Windows Forms, utilisez le <xref:System.AppDomain.UnhandledException> Gestionnaire d’événements.  
+ Vous pouvez choisir si ce événement doit servir de callback pour les exceptions Windows Forms non gérées en définissant <xref:System.Windows.Forms.Application.SetUnhandledExceptionMode%2A>. Pour intercepter les exceptions qui se produisent dans les threads non créés et détenus par Windows Forms, utilisez l'événement <xref:System.AppDomain.UnhandledException>.
   
 > [!NOTE]
->  Pour garantir qu’aucune activation de cet événement n’est pas incluses, vous devez attacher un gestionnaire avant d’appeler <xref:System.Windows.Application.Run%2A?displayProperty=nameWithType>.  
+>  Pour garantir qu’aucune activation de cet événement ne soit manquée, vous devez attacher un gestionnaire avant d’appeler <xref:System.Windows.Application.Run%2A?displayProperty=nameWithType>.  
   
 > [!CAUTION]
->  Comme il s’agit d’un événement statique, vous devez détacher vos gestionnaires d’événements lorsque votre application est supprimée, ou entraînent des fuites de mémoire.  
+>  S'agissant d'un événement statique, vous devez détacher vos gestionnaires d’événements lorsque votre application est supprimée, faute de quoi des fuites mémoire vont se produire.  
   
    
   
 ## Examples  
- L’exemple de code suivant définit des gestionnaires d’événements pour les exceptions qui se produisent sur les threads de Windows Forms et les exceptions qui se produisent sur d’autres threads. Il définit <xref:System.Windows.Forms.Application.SetUnhandledExceptionMode%2A> afin que toutes les exceptions sont gérées par l’application, quels que soient les paramètres dans le fichier de configuration de l’application utilisateur. Il utilise le <xref:System.Windows.Forms.Application.ThreadException> événement à gérer les exceptions de thread d’interface utilisateur et le <xref:System.AppDomain.UnhandledException> événement à gérer les exceptions de thread d’interface utilisateur. Dans la mesure où <xref:System.AppDomain.UnhandledException> ne peut pas empêcher une application de se terminer, l’exemple enregistre simplement l’erreur dans le journal des événements application avant l’arrêt.  
+ L’exemple de code suivant définit des gestionnaires d’événements pour les exceptions qui se produisent sur les threads Windows Forms et les exceptions qui se produisent sur d’autres threads. Il définit <xref:System.Windows.Forms.Application.SetUnhandledExceptionMode%2A> afin que toutes les exceptions soient gérées par l’application, quels que soient les paramètres dans le fichier de configuration de l’application utilisateur. Il utilise l'événement <xref:System.Windows.Forms.Application.ThreadException> pour gérer les exceptions de thread d’interface utilisateur et l'événement <xref:System.AppDomain.UnhandledException> pour gérer les exceptions issues de threads autres que celui de l’interface utilisateur. Dans la mesure où <xref:System.AppDomain.UnhandledException> ne peut pas empêcher une application de se terminer, l’exemple enregistre simplement l’erreur dans le journal des événements application avant l’arrêt.  
   
- Cet exemple suppose que vous avez défini deux <xref:System.Windows.Forms.Button> contrôles, `button1` et `button2`, dans votre <xref:System.Windows.Forms.Form> classe.  
+ Cet exemple suppose que vous avez défini deux contrôles <xref:System.Windows.Forms.Button>, `button1` et `button2`, dans votre classe <xref:System.Windows.Forms.Form>.  
   
  [!code-cpp[Classic Application.ThreadException Example#1](~/samples/snippets/cpp/VS_Snippets_Winforms/Classic Application.ThreadException Example/CPP/source.cpp#1)]
  [!code-csharp[Classic Application.ThreadException Example#1](~/samples/snippets/csharp/VS_Snippets_Winforms/Classic Application.ThreadException Example/CS/source.cs#1)]

--- a/xml/System.Windows.Forms/Application.xml
+++ b/xml/System.Windows.Forms/Application.xml
@@ -1720,14 +1720,14 @@ Ce chemin d'accès sera différent selon que l'application Windows Forms est dé
         <ReturnType>System.Threading.ThreadExceptionEventHandler</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Se produit lorsqu'une exception non gérée est levée sur un thread d'interface utilisateur.</summary>
+        <summary>Se produit lorsqu'une exception non gérée est levée sur un thread.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- Cet événement permet à votre application Windows Forms de gérer les exceptions non prises en charge qui se produisent dans les threads de Windows Forms. Attachez vos gestionnaires à l'événement <xref:System.Windows.Forms.Application.ThreadException> pour traiter ces exceptions, ce qui laissera votre application dans un état indeterminé. Dans la mesure du possible, les exceptions doivent être gérées localement par un bloc structurant de gestion d'exceptions.
+ Cet événement permet à votre application Windows Forms de gérer les exceptions non prises en charge qui se produisent dans les threads de Windows Forms. Attachez vos gestionnaires d’événements à l'événement <xref:System.Windows.Forms.Application.ThreadException> pour traiter ces exceptions, qui laisseront votre application dans un état indeterminé. Dans la mesure du possible, les exceptions doivent être gérées localement par un bloc structuré de gestion des exceptions.
   
- Vous pouvez choisir si ce événement doit servir de callback pour les exceptions Windows Forms non gérées en définissant <xref:System.Windows.Forms.Application.SetUnhandledExceptionMode%2A>. Pour intercepter les exceptions qui se produisent dans les threads non créés et détenus par Windows Forms, utilisez l'événement <xref:System.AppDomain.UnhandledException>.
+ Vous pouvez choisir si ce rappel doit être utilisé pour les exceptions Windows Forms non gérées en définissant <xref:System.Windows.Forms.Application.SetUnhandledExceptionMode%2A>. Pour intercepter les exceptions qui se produisent dans les threads non créés et détenus par Windows Forms, utilisez l'événement <xref:System.AppDomain.UnhandledException>.
   
 > [!NOTE]
 >  Pour garantir qu’aucune activation de cet événement ne soit manquée, vous devez attacher un gestionnaire avant d’appeler <xref:System.Windows.Application.Run%2A?displayProperty=nameWithType>.  
@@ -1738,7 +1738,7 @@ Ce chemin d'accès sera différent selon que l'application Windows Forms est dé
    
   
 ## Examples  
- L’exemple de code suivant définit des gestionnaires d’événements pour les exceptions qui se produisent sur les threads Windows Forms et les exceptions qui se produisent sur d’autres threads. Il définit <xref:System.Windows.Forms.Application.SetUnhandledExceptionMode%2A> afin que toutes les exceptions soient gérées par l’application, quels que soient les paramètres dans le fichier de configuration de l’application utilisateur. Il utilise l'événement <xref:System.Windows.Forms.Application.ThreadException> pour gérer les exceptions de thread d’interface utilisateur et l'événement <xref:System.AppDomain.UnhandledException> pour gérer les exceptions issues de threads autres que celui de l’interface utilisateur. Dans la mesure où <xref:System.AppDomain.UnhandledException> ne peut pas empêcher une application de se terminer, l’exemple enregistre simplement l’erreur dans le journal des événements application avant l’arrêt.  
+ L’exemple de code suivant définit des gestionnaires d’événements pour les exceptions qui se produisent sur les threads Windows Forms et les exceptions qui se produisent sur d’autres threads. Il définit <xref:System.Windows.Forms.Application.SetUnhandledExceptionMode%2A> afin que toutes les exceptions soient gérées par l’application, quels que soient les paramètres dans le fichier de configuration de l’application utilisateur. Il utilise l'événement <xref:System.Windows.Forms.Application.ThreadException> pour gérer les exceptions de thread d’interface utilisateur et l'événement <xref:System.AppDomain.UnhandledException> pour gérer les exceptions issues de threads autres que celui de l’interface utilisateur. Dans la mesure où <xref:System.AppDomain.UnhandledException> ne peut pas empêcher une application de se terminer, l’exemple enregistre simplement l’erreur dans le journal des événements d’application avant l’arrêt. 
   
  Cet exemple suppose que vous avez défini deux contrôles <xref:System.Windows.Forms.Button>, `button1` et `button2`, dans votre classe <xref:System.Windows.Forms.Form>.  
   


### PR DESCRIPTION
#4 
The current text for this event seems to be automatically generated, which result in a not so good translation. The one I suggest here should be a bit more correct.